### PR TITLE
Rebel dev

### DIFF
--- a/html/HookListener.php
+++ b/html/HookListener.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once("HookNode.php");
+
+if (HookNode::verifyRegisteredBroker($_SERVER['REMOTE_ADDR'])) {
+    $req = new stdClass();
+
+    foreach ($_POST as $key => $value ) {
+        $req->$key = $value;
+    }
+
+    $req->responseAddress = $_SERVER['REMOTE_ADDR'] . ':' .  $_SERVER['REMOTE_PORT'];
+
+    processRequest($req);
+} else {
+    die("PERMISSION DENIED");
+}
+
+function processRequest($request)
+{
+    var_dump($request);
+
+    if (isset($request->command)) {
+
+        switch ($request->command) {
+            case 'attachToTangle':
+                HookNode::attachTx($request);
+                break;
+            case 'getNodeInfo':
+                echo "getNodeInfo";
+                break;
+            case 'broadcastTransactions':
+                echo 'broadcastTransactions';
+                break;
+            case 'getNeighbors':
+                echo "getNeighbors";
+                break;
+            default:
+                echo "i equals 2";
+                break;
+        }
+    } else {
+        die("NO COMMAND PROVIDED");
+    }
+}
+
+

--- a/html/HookListener.php
+++ b/html/HookListener.php
@@ -2,6 +2,12 @@
 
 require_once("HookNode.php");
 
+/*
+ * TODOS: This falls calls a stubbed-out method that Arthur is working on.  His
+ * work should either be added into that stubbed-out method, or remove that method
+ * and replace with his method and replace the call.
+ */
+
 if (HookNode::verifyRegisteredBroker($_SERVER['REMOTE_ADDR'])) {
     $req = new stdClass();
 
@@ -18,25 +24,14 @@ if (HookNode::verifyRegisteredBroker($_SERVER['REMOTE_ADDR'])) {
 
 function processRequest($request)
 {
-    var_dump($request);
-
     if (isset($request->command)) {
 
         switch ($request->command) {
             case 'attachToTangle':
                 HookNode::attachTx($request);
                 break;
-            case 'getNodeInfo':
-                echo "getNodeInfo";
-                break;
-            case 'broadcastTransactions':
-                echo 'broadcastTransactions';
-                break;
-            case 'getNeighbors':
-                echo "getNeighbors";
-                break;
             default:
-                echo "i equals 2";
+                die("UNRECOGNIZED COMMAND");
                 break;
         }
     } else {

--- a/html/HookListener.php
+++ b/html/HookListener.php
@@ -3,7 +3,7 @@
 require_once("HookNode.php");
 
 /*
- * TODOS: This falls calls a stubbed-out method that Arthur is working on.  His
+ * TODOS: This calls a stubbed-out method that Arthur is working on.  His
  * work should either be added into that stubbed-out method, or remove that method
  * and replace with his method and replace the call.
  */

--- a/html/HookNode.php
+++ b/html/HookNode.php
@@ -24,15 +24,9 @@ class HookNode
         if (property_exists($transactionObject, 'trunkTransaction')) {
             try {
                 $trytesToBroadcast = self::attachToTangle($transactionObject);
-            } catch (Exception $e) {
-                echo "Caught exception: " . $e->getMessage() . $GLOBALS['nl'];
-                return;
-            }
-        }
-
-        if ($trytesToBroadcast != NULL) {
-            try {
-                self::broadcastTransactions($trytesToBroadcast);
+                if ($trytesToBroadcast != NULL) {
+                    self::broadcastTransactions($trytesToBroadcast);
+                }
             } catch (Exception $e) {
                 echo "Caught exception: " . $e->getMessage() . $GLOBALS['nl'];
                 return;
@@ -96,10 +90,5 @@ class HookNode
         } else {
             throw new Exception('storeTransactions failed!');
         }
-    }
-
-    private static function sendResponse()
-    {
-
     }
 }

--- a/html/HookNode.php
+++ b/html/HookNode.php
@@ -6,19 +6,13 @@ require_once("requests/IriData.php");
 class HookNode
 {
 
-    public function __construct($nodeUrl, $apiVersion = '1.4', $nodeId = 'OYSTERPEARL')
+    public static function verifyRegisteredBroker($brokerIp)
     {
-    }
-
-    public static function verifyRegisteredBroker($brokerIp) {
         return true;
         /*TODO
 
-        hooknode needs to check if it knows the broker
-        for now, just pretend we do
-
-        We should report the result of this check to the broker
-        so it can either wait or move on to the next hooknode node
+        Put Arthur's stuff in here or get rid of this method and replace with
+        the new method.
 
         */
     }
@@ -76,10 +70,36 @@ class HookNode
         $command->command = "broadcastTransactions";
         $command->trytes = $trytesToBroadcast;
 
-        $req->makeRequest($command);
+        $result = $req->makeRequest($command);
+
+        if (!is_null($result) && property_exists($result, 'duration') &&
+            !property_exists($result, 'error')) {
+            self::storeTransactions($trytesToBroadcast);
+        } else {
+            throw new Exception('broadcastTransaction failed!');
+        }
     }
 
-    private static function sendResponse() {
+    private static function storeTransactions($trytes)
+    {
+        $req = new IriWrapper();
+
+        $command = new stdClass();
+        $command->command = "storeTransactions";
+        $command->trytes = $trytes;
+
+        $result = $req->makeRequest($command);
+
+        if (!is_null($result) && property_exists($result, 'duration') &&
+            !property_exists($result, 'error')) {
+            return $result;
+        } else {
+            throw new Exception('storeTransactions failed!');
+        }
+    }
+
+    private static function sendResponse()
+    {
 
     }
 }

--- a/html/HookNode.php
+++ b/html/HookNode.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once("requests/IriWrapper.php");
+require_once("requests/IriData.php");
+
+class HookNode
+{
+
+    public function __construct($nodeUrl, $apiVersion = '1.4', $nodeId = 'OYSTERPEARL')
+    {
+    }
+
+    public static function verifyRegisteredBroker($brokerIp) {
+        return true;
+        /*TODO
+
+        hooknode needs to check if it knows the broker
+        for now, just pretend we do
+
+        We should report the result of this check to the broker
+        so it can either wait or move on to the next hooknode node
+
+        */
+    }
+
+    public static function attachTx($transactionObject)
+    {
+        $trytesToBroadcast = NULL;
+
+        if (property_exists($transactionObject, 'trunkTransaction')) {
+            try {
+                $trytesToBroadcast = self::attachToTangle($transactionObject);
+            } catch (Exception $e) {
+                echo "Caught exception: " . $e->getMessage() . $GLOBALS['nl'];
+                return;
+            }
+        }
+
+        if ($trytesToBroadcast != NULL) {
+            try {
+                self::broadcastTransactions($trytesToBroadcast);
+            } catch (Exception $e) {
+                echo "Caught exception: " . $e->getMessage() . $GLOBALS['nl'];
+                return;
+            }
+        }
+    }
+
+    private static function attachToTangle($transactionObject)
+    {
+        $req = new IriWrapper();
+
+        $command = new stdClass();
+        $command->command = "attachToTangle";
+
+        $command->minWeightMagnitude = IriData::$minWeightMagnitude;
+
+        $command->trunkTransaction = $transactionObject->trunkTransaction;
+        $command->branchTransaction = $transactionObject->branchTransaction;
+        $command->trytes = $transactionObject->trytes;
+
+        $resultOfAttach = $req->makeRequest($command);
+
+        if (!is_null($resultOfAttach) && property_exists($resultOfAttach, 'trytes')) {
+            return $resultOfAttach->trytes;
+        } else {
+            throw new Exception('attachToTangle failed!');
+        }
+    }
+
+    private static function broadcastTransactions($trytesToBroadcast)
+    {
+        $req = new IriWrapper();
+
+        $command = new stdClass();
+        $command->command = "broadcastTransactions";
+        $command->trytes = $trytesToBroadcast;
+
+        $req->makeRequest($command);
+    }
+
+    private static function sendResponse() {
+
+    }
+}

--- a/html/requests/IriData.php
+++ b/html/requests/IriData.php
@@ -1,0 +1,22 @@
+<?php
+
+$GLOBALS['nl'] = "\n";
+
+class IriData
+{
+
+    public static $nodeUrl = "http://localhost:14265";
+    public static $apiVersion = '1.4';
+
+    public static $depthToSearchForTxs = 1;
+    public static $minDepth = 1;
+    public static $minWeightMagnitude = 14;
+    public static $minMinWeightMagnitude = 14;
+
+    public static $oysterSeed = 'OYSTERPRLOYSTERPRLOYSTERPRL9YSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRL';
+    public static $oysterTag = 'OYSTERPEARL';  //will use this as the 'tag'
+    public static $txValue = 0;
+
+    public static $maxIRICallAttempts = 50;  //we need to discuss this
+}
+

--- a/html/requests/IriData.php
+++ b/html/requests/IriData.php
@@ -13,7 +13,7 @@ class IriData
     public static $minWeightMagnitude = 14;
     public static $minMinWeightMagnitude = 14;
 
-    public static $oysterSeed = 'OYSTERPRLOYSTERPRLOYSTERPRL9YSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRL';
+    public static $oysterSeed = 'OYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRL';
     public static $oysterTag = 'OYSTERPEARL';  //will use this as the 'tag'
     public static $txValue = 0;
 

--- a/html/requests/IriWrapper.php
+++ b/html/requests/IriWrapper.php
@@ -1,0 +1,80 @@
+<?php
+require_once("IriData.php");
+
+class IriWrapper
+{
+
+    private $headers = array(
+        'Content-Type: application/json',
+    );
+    public $nodeUrl;
+    private $userAgent = 'Codular Sample cURL Request';
+    private $apiVersionHeaderString = 'X-IOTA-API-Version: ';
+
+    public function __construct()
+    {
+        /*$nodeUrl is expected in the following format:
+            http://1.2.3.4:14265  (if using IP)
+                or
+            http://host:14265  (if using host)
+        */
+        try {
+            $this->validateUrl(IriData::$nodeUrl);
+            array_push($this->headers, $this->apiVersionHeaderString . IriData::$apiVersion);
+            $this->nodeUrl = IriData::$nodeUrl;
+
+        } catch (Exception $e) {
+            echo 'Caught exception: ' . $e->getMessage() . $GLOBALS['nl'];
+        }
+    }
+
+    private function validateUrl($nodeUrl)
+    {
+        $http = "((http)\:\/\/)"; // starts with http://
+        $port = "(\:[0-9]{2,5})"; // ends with :(port)
+
+        /*TODOS
+        add auth tokens to regex test
+        */
+
+        if (preg_match("/^$http/", $nodeUrl) && preg_match("/$port$/", $nodeUrl)) {
+            return true;
+        } else {
+            throw new Exception('Invalid URL.');
+        }
+    }
+
+    public function makeRequest($commandObject)
+    {
+        $payload = json_encode($commandObject);
+
+        $curl = curl_init();
+
+        curl_setopt_array($curl, array(
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_POST => 1,
+            CURLOPT_URL => $this->nodeUrl,
+            CURLOPT_USERAGENT => $this->userAgent,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HTTPHEADER => $this->headers,
+            CURLOPT_CONNECTTIMEOUT => 0,
+            CURLOPT_TIMEOUT => 1000
+        ));
+
+        echo $GLOBALS['nl'];
+        echo $GLOBALS['nl'] . "calling curl, url is: " . $this->nodeUrl . $GLOBALS['nl'];
+        echo "command: " . $commandObject->command . $GLOBALS['nl'];
+        echo $GLOBALS['nl'] . "payload: " . $payload . $GLOBALS['nl'];
+
+        //echo $GLOBALS['nl'] . "SLEEPING" . $GLOBALS['nl'];
+        //sleep(5);
+
+        $response = json_decode(curl_exec($curl));
+        curl_close($curl);
+
+        echo $GLOBALS['nl'] . "response was: " . $GLOBALS['nl'];
+        var_dump($response);
+
+        return $response;
+    }
+}

--- a/html/requests/IriWrapper.php
+++ b/html/requests/IriWrapper.php
@@ -22,7 +22,6 @@ class IriWrapper
             $this->validateUrl(IriData::$nodeUrl);
             array_push($this->headers, $this->apiVersionHeaderString . IriData::$apiVersion);
             $this->nodeUrl = IriData::$nodeUrl;
-
         } catch (Exception $e) {
             echo 'Caught exception: ' . $e->getMessage() . $GLOBALS['nl'];
         }
@@ -34,7 +33,8 @@ class IriWrapper
         $port = "(\:[0-9]{2,5})"; // ends with :(port)
 
         /*TODOS
-        add auth tokens to regex test
+        If we decide to add authentication to urls, add auth tokens to regex test.
+        Probably not needed for testnet A.
         */
 
         if (preg_match("/^$http/", $nodeUrl) && preg_match("/$port$/", $nodeUrl)) {
@@ -61,19 +61,9 @@ class IriWrapper
             CURLOPT_TIMEOUT => 1000
         ));
 
-        echo $GLOBALS['nl'];
-        echo $GLOBALS['nl'] . "calling curl, url is: " . $this->nodeUrl . $GLOBALS['nl'];
-        echo "command: " . $commandObject->command . $GLOBALS['nl'];
-        echo $GLOBALS['nl'] . "payload: " . $payload . $GLOBALS['nl'];
-
-        //echo $GLOBALS['nl'] . "SLEEPING" . $GLOBALS['nl'];
-        //sleep(5);
-
         $response = json_decode(curl_exec($curl));
-        curl_close($curl);
 
-        echo $GLOBALS['nl'] . "response was: " . $GLOBALS['nl'];
-        var_dump($response);
+        curl_close($curl);
 
         return $response;
     }

--- a/html/requests/NodeMessenger.php
+++ b/html/requests/NodeMessenger.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once("IriData.php");
+
+class NodeMessenger
+{
+
+    private $headers = array(
+        'Content-Type: application/x-www-form-urlencoded',
+    );
+    public $nodeUrl;
+    private $userAgent = 'Codular Sample cURL Request';
+    private $apiVersionHeaderString = 'X-IOTA-API-Version: ';
+
+    public function __construct()
+    {
+
+        array_push($this->headers, $this->apiVersionHeaderString . $GLOBALS['apiVersion']);
+    }
+
+    private function validateUrl($nodeUrl)
+    {
+
+        $http = "((http)\:\/\/)"; // starts with http://
+        $port = "(\:[0-9]{2,5})"; // ends with a port
+
+        if (preg_match("/^$http/", $nodeUrl) && preg_match("/$port$/", $nodeUrl)) {
+            return true;
+        } else {
+            throw new Exception('Invalid URL.');
+        }
+    }
+
+<<<<<<< HEAD
+    public function sendMessageToNode($commandObject, $nodeUrl)
+=======
+    public function sendMessageToNode($nodeUrl, $commandObject)
+>>>>>>> 4aba6e79cf1c908dfb854c83651b384e9a18c4b6
+    {
+
+        try {
+            $this->validateUrl($nodeUrl);
+        } catch (Exception $e) {
+            echo 'Caught exception: ' . $e->getMessage() . $GLOBALS['nl'];
+        }
+
+        $payload = http_build_query($commandObject);
+
+        $curl = curl_init();
+
+        curl_setopt_array($curl, array(
+            //CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_POST => 1,
+            CURLOPT_URL => $nodeUrl,
+            CURLOPT_USERAGENT => $this->userAgent,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_HTTPHEADER => $this->headers,
+            CURLOPT_CONNECTTIMEOUT => 0,
+            CURLOPT_TIMEOUT => 1000
+        ));
+
+        echo $GLOBALS['nl'];
+        echo $GLOBALS['nl'] . "calling curl in nodeMessenger, url is: " . $nodeUrl . $GLOBALS['nl'];
+        echo $GLOBALS['nl'] . "payload: " . $payload . $GLOBALS['nl'];
+
+        $response = json_decode(curl_exec($curl));
+        curl_close($curl);
+
+        echo $GLOBALS['nl'] . "response was: " . $GLOBALS['nl'];
+        var_dump($response);
+
+        return $response;
+    }
+
+    public function sendMessageToClient($commandObject, $url)
+    {
+
+    }
+}
+
+

--- a/html/requests/NodeMessenger.php
+++ b/html/requests/NodeMessenger.php
@@ -15,7 +15,7 @@ class NodeMessenger
     public function __construct()
     {
 
-        array_push($this->headers, $this->apiVersionHeaderString . $GLOBALS['apiVersion']);
+        array_push($this->headers, $this->apiVersionHeaderString . IriData::$apiVersion);
     }
 
     private function validateUrl($nodeUrl)
@@ -31,13 +31,8 @@ class NodeMessenger
         }
     }
 
-<<<<<<< HEAD
     public function sendMessageToNode($commandObject, $nodeUrl)
-=======
-    public function sendMessageToNode($nodeUrl, $commandObject)
->>>>>>> 4aba6e79cf1c908dfb854c83651b384e9a18c4b6
     {
-
         try {
             $this->validateUrl($nodeUrl);
         } catch (Exception $e) {
@@ -49,7 +44,7 @@ class NodeMessenger
         $curl = curl_init();
 
         curl_setopt_array($curl, array(
-            //CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_POST => 1,
             CURLOPT_URL => $nodeUrl,
             CURLOPT_USERAGENT => $this->userAgent,
@@ -59,15 +54,9 @@ class NodeMessenger
             CURLOPT_TIMEOUT => 1000
         ));
 
-        echo $GLOBALS['nl'];
-        echo $GLOBALS['nl'] . "calling curl in nodeMessenger, url is: " . $nodeUrl . $GLOBALS['nl'];
-        echo $GLOBALS['nl'] . "payload: " . $payload . $GLOBALS['nl'];
-
         $response = json_decode(curl_exec($curl));
-        curl_close($curl);
 
-        echo $GLOBALS['nl'] . "response was: " . $GLOBALS['nl'];
-        var_dump($response);
+        curl_close($curl);
 
         return $response;
     }


### PR DESCRIPTION
Broker node can now call hook node on a certain port if it uses the right IP address and the hook node has the proper nginx configuration.  I'm arbitrarily using 250, but we can make it be whatever port we want, we'd just have to configure nginx correctly and make sure the brokernode's sendToHookNode method gets updated.

-hook node receives the PoW request from the broker node, then calls attachToTangle, broadcastTransactions, and storeTransactions.