### PR TITLE
Makefile: default target, clean up, fix build on latest go (1.10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
-install-deps:
-	go get -u github.com/golang/dep/cmd/dep \
-	&& go get github.com/codegangsta/gin \
-	&& dep ensure
+NAME=hooknode
 
-start:
-	dep ensure \
-	&& go build -o ./bin/main . \
-	&& ./bin/main
+all: ${NAME}
+
+install-deps:
+	test -x "$(shell which go)"
+	test -x "$(shell which dep)" || go get -u github.com/golang/dep/cmd/dep
+	test -x "$(shell which gin)" || go get github.com/codegangsta/gin
+	dep ensure -update
+
+${NAME}:
+	test -x "$(shell which dep)" || ${MAKE} install-deps
+	dep ensure && \
+	CGO_LDFLAGS_ALLOW='.*' go build -o ./bin/${NAME}
+	@echo "Build Success"
+	@printf 'sha256: '
+	@sha256sum ${NAME}
+
+start: ${NAME}
+	./bin/${NAME} 
 
 start-dev:
 	gin -i run main.go
+
+.PHONY: ${NAME}
+


### PR DESCRIPTION
I ran into an issue building with the latest version of Go, which led to a small refactor of the Makefile. Let me know what you think, or if anything needs changing before merge. I imagine we will be adding more targets (test, cross compile, etc) and the LDFLAGS_ALLOW will change in the future.

  * `make install-deps` instead of building deps all the time, only build if they don't exist. another option would be to have a separate `update-deps` target.

  * `make install-deps` update vendor dir

  * `make hooknode` add linker flag whitelist (fix *giota* build for go 1.10)

  * output file was `./bin/main`, moved to `./hooknode`

  * add *phony* target, allowing rebuilding